### PR TITLE
chore(package): Make sure only relevant data is included in the package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   global:
     - CRATE_NAME=signify
 
+rust:
+
 matrix:
   fast_finish: true
 
@@ -41,6 +43,9 @@ matrix:
       os: osx
       rust: nightly
       if: type = pull_request OR branch = staging OR branch = trying OR branch =~ /^v\d+/
+
+  allow_failures:
+      - rust: nightly
 
 before_install:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ matrix:
 
   allow_failures:
       - rust: nightly
+      - rust: beta
 
 before_install:
   - set -e

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,14 @@ homepage = "https://github.com/badboy/signify-rs"
 repository = "https://github.com/badboy/signify-rs"
 
 include = [
-  "Cargo.toml",
-  "README*",
-  "LICENSE*",
-  "src/**/*",
-  "tests/**/*",
-  "examples/**/*",
+  "/Cargo.toml",
+  "/README*",
+  "/LICENSE*",
+  "/src/**/*",
+  "/tests/compare.sh",
+  "/tests/full-cycle.sh",
+  "/tests/integration.sh",
+  "/examples/**/*",
 ]
 
 [dependencies]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,13 @@ environment:
     - TARGET: x86_64-pc-windows-msvc
       RUST_VERSION: nightly
 
+matrix:
+    allow_failures:
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: nightly
+
 install:
   - ps: >-
       If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {


### PR DESCRIPTION
Previously, it included the whole temporary C implementation as well, blowing up the package size.
This is fixed now.