### PR TITLE
Remove failure dep and start adding library-like errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,40 +3,10 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -88,12 +58,6 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "cc"
-version = "1.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -201,28 +165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,12 +184,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -291,25 +227,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -433,12 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
 name = "sha2"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,7 +377,6 @@ dependencies = [
  "byteorder",
  "clap",
  "ed25519-dalek",
- "failure",
  "rand_core",
  "rpassword",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,3 @@ clap = { version = "3.0.0-beta.5", default-features = false, features = ["cargo"
 rpassword = "5"
 ed25519-dalek = { version = "1", default-features = false, features = ["alloc", "u64_backend"] }
 rand_core = { version = "0.5", features = ["getrandom"] }
-failure = "0.1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,72 @@
-pub use failure::err_msg;
+use crate::structs::KeyNumber;
+use std::fmt::{self, Display};
+use std::io;
 
-pub type Result<T> = ::std::result::Result<T, failure::Error>;
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    InvalidFormat(FormatError),
+    UnsupportedAlgorithm,
+    MismatchedKey {
+        expected: KeyNumber,
+        found: KeyNumber,
+    },
+    BadSignature,
+    BadPassword,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Io(e) => Display::fmt(e, f),
+            Error::InvalidFormat(e) => Display::fmt(e, f),
+            Error::UnsupportedAlgorithm => f.write_str("encountered unsupported key algorithm"),
+            Error::MismatchedKey { expected, found } => write!(f,
+                "failed to verify signature: the wrong key was used. Expected #{:?}, but found {:?}",
+                expected,
+                found,
+            ),
+            Error::BadSignature => f.write_str("signature verification failed"),
+            Error::BadPassword => f.write_str("password was empty"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[derive(Debug)]
+pub enum FormatError {
+    LineLength,
+    Comment { expected: &'static str },
+    MissingNewline,
+    Base64,
+}
+
+impl Display for FormatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FormatError::LineLength => {
+                f.write_str("encountered an invalidly formatted line of data")
+            }
+            FormatError::Comment { expected } => {
+                write!(f, "line missing comment; expected {}", expected)
+            }
+            FormatError::MissingNewline => f.write_str("expected newline was not found"),
+            FormatError::Base64 => f.write_str("encountered invalid base64 data"),
+        }
+    }
+}
+
+impl std::error::Error for FormatError {}
+
+impl From<FormatError> for Error {
+    fn from(e: FormatError) -> Self {
+        Self::InvalidFormat(e)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}


### PR DESCRIPTION
Removing failure also drops quite a few dependencies from the tree.

This loses some "context" for sure (like filenames) but I think it should still be pretty obvious what might be mis-formed since at most the CLI takes 2 file parameters at a time. I think that when the CLI is revisited (again) later and something like `anyhow` is introduced, its `Context` should help bring parts back.

Part 1/2 of the initial set of larger set of changes to make a standalone lib.