### PR TITLE
Add documentation to libsignify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "byteorder",
  "ed25519-dalek",
  "rand_core",
+ "static_assertions",
 ]
 
 [[package]]
@@ -388,6 +389,12 @@ dependencies = [
  "rand_core",
  "rpassword",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"

--- a/libsignify/Cargo.toml
+++ b/libsignify/Cargo.toml
@@ -19,3 +19,6 @@ bcrypt-pbkdf = "0.7"
 base64 = "0.13"
 ed25519-dalek = { version = "1", default-features = false, features = ["alloc", "u64_backend"] }
 rand_core = "0.5"
+
+[dev-dependencies]
+static_assertions = "1"

--- a/libsignify/src/consts.rs
+++ b/libsignify/src/consts.rs
@@ -2,13 +2,17 @@
 
 use rand_core::RngCore;
 
-const KEYNUM_LEN: usize = 8;
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct KeyNumber([u8; KEYNUM_LEN]);
+/// A number identifying a certain signing keypair.
+///
+/// A short and easy to read [8 byte] digest of the key.
+///
+/// [8 byte]: Self::LEN
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct KeyNumber([u8; Self::LEN]);
 
 impl KeyNumber {
-    pub const LEN: usize = KEYNUM_LEN;
+    /// The length of the key number, in bytes (8).
+    pub const LEN: usize = 8;
 
     pub(crate) fn new(num: [u8; Self::LEN]) -> Self {
         Self(num)
@@ -37,4 +41,29 @@ pub(crate) const KDFALG: [u8; 2] = *b"BK";
 pub(crate) const COMMENT_HEADER: &str = "untrusted comment: ";
 pub(crate) const COMMENT_MAX_LEN: usize = 1024;
 
+/// The recommended number of KDF rounds to use when encrypting new secret keys.
+///
+/// This value was selected to mirror the [OpenBSD implementation]'s choice.
+///
+/// [OpenBSD implementation]: https://github.com/aperezdc/signify/blob/fa123eda2774c38abf98e43946baf604df85aea0/signify.c#L875
 pub const DEFAULT_KDF_ROUNDS: u32 = 42;
+
+#[cfg(test)]
+mod tests {
+    use super::KeyNumber;
+    use std::fmt::Debug;
+    use std::hash::Hash;
+
+    static_assertions::assert_impl_all!(
+        KeyNumber: Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        Ord,
+        PartialOrd,
+        Send,
+        Sync
+    );
+}

--- a/libsignify/src/errors.rs
+++ b/libsignify/src/errors.rs
@@ -24,7 +24,7 @@ pub enum Error {
     ///
     /// The contents of the message should not be trusted if this is encountered.
     BadSignature,
-    /// Provided password was empty.
+    /// Provided password was empty or couldn't decrypt a private key.
     BadPassword,
 }
 

--- a/libsignify/src/errors.rs
+++ b/libsignify/src/errors.rs
@@ -2,16 +2,29 @@ use crate::consts::KeyNumber;
 use std::fmt::{self, Display};
 use std::io;
 
+/// The error type which is returned when some `signify` operation fails.
 #[derive(Debug)]
 pub enum Error {
+    /// An I/O error occured working with structure data.
     Io(io::Error),
+    /// Parsing a structure's data yielded an error.
     InvalidFormat(FormatError),
+    /// The key algorithm used was unknown and unsupported.
     UnsupportedAlgorithm,
+    /// Attempted to verify a signature with the wrong public key.
     MismatchedKey {
+        /// ID of the key which created the signature.
         expected: KeyNumber,
+        /// ID of the key that tried to verify the signature, but was wrong.
         found: KeyNumber,
     },
+    /// The signature didn't match the expected result.
+    ///
+    /// This could be the result of data corruption or malicious tampering.
+    ///
+    /// The contents of the message should not be trusted if this is encountered.
     BadSignature,
+    /// Provided password was empty.
     BadPassword,
 }
 
@@ -36,11 +49,20 @@ impl Display for Error {
 
 impl std::error::Error for Error {}
 
+/// The error that is returned when a file's contents didn't adhere
+/// to the `signify` file container format.
 #[derive(Debug)]
 pub enum FormatError {
+    /// A comment line exceeded the maximum length or a data line was empty.
     LineLength,
-    Comment { expected: &'static str },
+    /// File was missing the required `untrusted comment: ` preamble.
+    Comment {
+        /// The expected comment header.
+        expected: &'static str,
+    },
+    /// File was missing a required line or wasn't correctly newline terminated.
     MissingNewline,
+    /// Provided data wasn't valid base64.
     Base64,
 }
 
@@ -71,4 +93,15 @@ impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Self::Io(e)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use static_assertions::assert_impl_all;
+    use std::error::Error as StdError;
+    use std::fmt::{Debug, Display};
+
+    assert_impl_all!(Error: Debug, Display, StdError, Send, Sync);
+    assert_impl_all!(FormatError: Debug, Display, StdError, Send, Sync);
 }

--- a/signify/Cargo.toml
+++ b/signify/Cargo.toml
@@ -13,6 +13,10 @@ license = "MIT"
 homepage = "https://github.com/badboy/signify-rs"
 repository = "https://github.com/badboy/signify-rs"
 
+[[bin]]
+name = "signify"
+doc = false
+
 [dependencies]
 clap = { version = "3.0.0-beta.5", default-features = false, features = ["cargo", "derive", "std"] }
 rand_core = { version = "0.5", features = ["getrandom"] }

--- a/signify/src/main.rs
+++ b/signify/src/main.rs
@@ -5,8 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use libsignify::{
-    consts::DEFAULT_KDF_ROUNDS, errors::Error, Codeable, NewKeyOpts, PrivateKey, PublicKey,
-    Signature,
+    consts::DEFAULT_KDF_ROUNDS, Codeable, Error, NewKeyOpts, PrivateKey, PublicKey, Signature,
 };
 
 use clap::Parser;
@@ -140,7 +139,7 @@ fn sign(
         None => format!("{}.sig", msg_path),
     };
 
-    let sig = secret_key.sign(&msg)?;
+    let sig = secret_key.sign(&msg);
 
     let sig_comment = "signature from signify secret key";
 
@@ -193,7 +192,7 @@ fn generate(
 
     // Store the private key
     let mut rng = rand_core::OsRng {};
-    let private_key = PrivateKey::derive(&mut rng, derivation_info)?;
+    let private_key = PrivateKey::generate(&mut rng, derivation_info)?;
 
     let priv_comment = format!("{} secret key", comment);
     let mut file = OpenOptions::new()


### PR DESCRIPTION
Heres the next set of changes :) Happy holidays as well (if you celebrate)

Starting off, documentation! Short of some examples on the few public methods, this covers 100% of the crate's public APIs in docs, with `#![warn(missing_docs)]` added to the crate root to make sure that it stays covered. I did my best to strike a balance between helpfulness and simplicity in the comments. In the process of writing them, I renamed the method that makes a new private key from `derive` to `generate` since `derive` wasn't really right because nothing about the inputs affected the actual keygen.

Also added `static_assertions` on all the public types to make it harder to accidentally break some part of the public API.

Last but not least, I added a few lines of code that actually check that the provided passphrase properly decrypted the private key. The OpenBSD implementation also does the same check and it leads to much better UX instead of possibly ending up with a broken key.

Part 1/3 of the set. 