### PR TITLE
Add secret material zeroization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "ed25519-dalek",
  "rand_core",
  "static_assertions",
+ "zeroize",
 ]
 
 [[package]]

--- a/libsignify/Cargo.toml
+++ b/libsignify/Cargo.toml
@@ -19,6 +19,7 @@ bcrypt-pbkdf = "0.7"
 base64 = "0.13"
 ed25519-dalek = { version = "1", default-features = false, features = ["alloc", "u64_backend"] }
 rand_core = "0.5"
+zeroize = "1.4"
 
 [dev-dependencies]
 static_assertions = "1"

--- a/libsignify/src/lib.rs
+++ b/libsignify/src/lib.rs
@@ -23,13 +23,13 @@ pub use errors::{Error, FormatError};
 mod key;
 pub use key::{NewKeyOpts, PrivateKey, PublicKey, Signature};
 
-use ed25519_dalek::{Keypair, Signer as _, Verifier as _};
+use ed25519_dalek::{Signer as _, Verifier as _};
 
 impl PrivateKey {
     /// Signs a message with this secret key and returns the signature.
     pub fn sign(&self, msg: &[u8]) -> Signature {
         // This `unwrap` is erased in release mode.
-        let keypair = Keypair::from_bytes(&self.complete_key).unwrap();
+        let keypair = ed25519_dalek::Keypair::from_bytes(self.complete_key.as_ref()).unwrap();
         let sig = keypair.sign(msg).to_bytes();
         Signature::new(self.keynum, sig)
     }


### PR DESCRIPTION
Since `zeroize` was already in the dependency tree, I decided it couldn't hurt to [add some cryptographic hygiene](https://docs.rs/zeroize/latest/zeroize/#what-about-clearing-registers-mlock-mprotect-etc) to `libsignify` by making a strong effort towards making sure that private keys and passphrases don't stay around in memory longer then needed.

Part 2/3