### PR TITLE
Remove usage of std::io and make libsignify no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         profile: minimal
         override: true
     - run: cargo test --all
+    - run: cargo test --features std
     - run: make full-cycle
     - run: make integration
     - name: Test comparing against C signify
@@ -57,3 +58,21 @@ jobs:
 
     - name: Docs
       run: cargo doc
+
+  no_std_build:
+    name: "Ensure no_std can build"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+    
+    - name: Build
+      run: |
+        rustup target add thumbv6m-none-eabi
+        cargo build -p libsignify --target thumbv6m-none-eabi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,6 @@ version = "0.4.2"
 dependencies = [
  "base64",
  "bcrypt-pbkdf",
- "byteorder",
  "ed25519-dalek",
  "rand_core",
  "static_assertions",

--- a/libsignify/Cargo.toml
+++ b/libsignify/Cargo.toml
@@ -14,7 +14,6 @@ homepage = "https://github.com/badboy/signify-rs"
 repository = "https://github.com/badboy/signify-rs"
 
 [dependencies]
-byteorder = "1.2"
 bcrypt-pbkdf = "0.7"
 base64 = "0.13"
 ed25519-dalek = { version = "1", default-features = false, features = ["alloc", "u64_backend"] }

--- a/libsignify/Cargo.toml
+++ b/libsignify/Cargo.toml
@@ -13,12 +13,15 @@ license = "MIT"
 homepage = "https://github.com/badboy/signify-rs"
 repository = "https://github.com/badboy/signify-rs"
 
+[features]
+std = []
+
 [dependencies]
-bcrypt-pbkdf = "0.7"
-base64 = "0.13"
+bcrypt-pbkdf = { version = "0.7", default-features = false }
+base64 = { version = "0.13", default-features = false, features = ["alloc"] }
 ed25519-dalek = { version = "1", default-features = false, features = ["alloc", "u64_backend"] }
-rand_core = "0.5"
-zeroize = "1.4"
+rand_core = { version = "0.5", default-features = false }
+zeroize = { version = "1.4", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 static_assertions = "1"

--- a/libsignify/src/consts.rs
+++ b/libsignify/src/consts.rs
@@ -51,8 +51,8 @@ pub const DEFAULT_KDF_ROUNDS: u32 = 42;
 #[cfg(test)]
 mod tests {
     use super::KeyNumber;
-    use std::fmt::Debug;
-    use std::hash::Hash;
+    use core::fmt::Debug;
+    use core::hash::Hash;
 
     static_assertions::assert_impl_all!(
         KeyNumber: Clone,

--- a/libsignify/src/encoding.rs
+++ b/libsignify/src/encoding.rs
@@ -3,9 +3,7 @@ use crate::consts::{
 };
 use crate::errors::{Error, FormatError};
 use crate::{KeyNumber, PrivateKey, PublicKey, Signature};
-
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{Read, Write};
+use std::io::Write;
 use zeroize::Zeroizing;
 
 /// A structure that can be converted to and from bytes and the `signify` file format.
@@ -40,7 +38,7 @@ pub trait Codeable: Sized + Sealed {
     ///
     /// When working with signature files, [`to_file_encoding`](Self::to_file_encoding)
     /// should be prefered for compatibility with other implementations.
-    fn as_bytes(&self) -> Result<Vec<u8>, Error>;
+    fn as_bytes(&self) -> Vec<u8>;
 
     /// Converts the structure into a base64 encoded container and returned the raw bytes.
     ///
@@ -49,18 +47,18 @@ pub trait Codeable: Sized + Sealed {
     /// The container format can be seen in the [decoder's documentation].
     ///
     /// [decoder's documentation]: Self::from_base64
-    fn to_file_encoding(&self, comment: &str) -> Result<Vec<u8>, Error> {
-        let bytes = self.as_bytes()?;
+    fn to_file_encoding(&self, comment: &str) -> Vec<u8> {
+        let bytes = self.as_bytes();
 
         let mut file_bytes = Vec::new();
 
-        file_bytes.write_all(COMMENT_HEADER.as_bytes())?;
-        writeln!(file_bytes, "{}", comment)?;
+        file_bytes.extend_from_slice(COMMENT_HEADER.as_bytes());
+        writeln!(file_bytes, "{}", comment).unwrap();
 
         let out = base64::encode(&bytes);
-        writeln!(file_bytes, "{}", out)?;
+        writeln!(file_bytes, "{}", out).unwrap();
 
-        Ok(file_bytes)
+        file_bytes
     }
 }
 
@@ -73,11 +71,27 @@ impl Sealed for PublicKey {}
 impl Sealed for PrivateKey {}
 impl Sealed for Signature {}
 
+struct SliceReader<'a>(&'a [u8]);
+
+impl SliceReader<'_> {
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() > self.0.len() {
+            return Err(Error::InsufficentData);
+        }
+        let (a, b) = self.0.split_at(buf.len());
+
+        buf.copy_from_slice(a);
+
+        self.0 = b;
+        Ok(())
+    }
+}
+
 impl Codeable for PublicKey {
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let mut buf = std::io::Cursor::new(bytes);
+        let mut buf = SliceReader(bytes);
 
-        let mut _pkgalg = [0; 2];
+        let mut _pkgalg = [0u8; 2];
         let mut keynum = [0; KeyNumber::LEN];
         let mut public_key = [0; PUBLIC_KEY_LEN];
 
@@ -91,20 +105,20 @@ impl Codeable for PublicKey {
         })
     }
 
-    fn as_bytes(&self) -> Result<Vec<u8>, Error> {
-        let mut w = Vec::new();
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
 
-        w.write_all(&PKGALG)?;
-        w.write_all(self.keynum.as_ref())?;
-        w.write_all(&self.key)?;
+        bytes.extend_from_slice(&PKGALG);
+        bytes.extend_from_slice(self.keynum.as_ref());
+        bytes.extend_from_slice(&self.key);
 
-        Ok(w)
+        bytes
     }
 }
 
 impl Codeable for PrivateKey {
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let mut buf = std::io::Cursor::new(bytes);
+        let mut buf = SliceReader(bytes);
 
         let mut public_key_alg = [0; 2];
         let mut kdf_alg = [0; 2];
@@ -115,7 +129,11 @@ impl Codeable for PrivateKey {
 
         buf.read_exact(&mut public_key_alg)?;
         buf.read_exact(&mut kdf_alg)?;
-        let kdf_rounds = buf.read_u32::<BigEndian>()?;
+        let kdf_rounds = {
+            let mut bytes = [0u8; std::mem::size_of::<u32>()];
+            buf.read_exact(&mut bytes)?;
+            u32::from_be_bytes(bytes)
+        };
         buf.read_exact(&mut salt)?;
         buf.read_exact(&mut checksum)?;
         buf.read_exact(&mut keynum)?;
@@ -132,26 +150,26 @@ impl Codeable for PrivateKey {
         })
     }
 
-    fn as_bytes(&self) -> Result<Vec<u8>, Error> {
-        let mut w = Vec::new();
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
 
-        w.write_all(&self.public_key_alg)?;
-        w.write_all(&self.kdf_alg)?;
-        w.write_u32::<BigEndian>(self.kdf_rounds)?;
-        w.write_all(&self.salt)?;
-        w.write_all(&self.checksum)?;
-        w.write_all(self.keynum.as_ref())?;
-        w.write_all(self.complete_key.as_ref())?;
+        bytes.extend_from_slice(&self.public_key_alg);
+        bytes.extend_from_slice(&self.kdf_alg);
+        bytes.extend_from_slice(&self.kdf_rounds.to_be_bytes());
+        bytes.extend_from_slice(&self.salt);
+        bytes.extend_from_slice(&self.checksum);
+        bytes.extend_from_slice(self.keynum.as_ref());
+        bytes.extend_from_slice(self.complete_key.as_ref());
 
-        Ok(w)
+        bytes
     }
 }
 
 impl Codeable for Signature {
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let mut buf = std::io::Cursor::new(bytes);
+        let mut buf = SliceReader(bytes);
 
-        let mut _pkgalg = [0; 2];
+        let mut _pkgalg = [0u8; 2];
         let mut keynum = [0; KeyNumber::LEN];
         let mut sig = [0; SIG_LEN];
 
@@ -165,14 +183,14 @@ impl Codeable for Signature {
         })
     }
 
-    fn as_bytes(&self) -> Result<Vec<u8>, Error> {
-        let mut w = Vec::new();
+    fn as_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
 
-        w.write_all(&PKGALG)?;
-        w.write_all(self.keynum.as_ref())?;
-        w.write_all(&self.sig)?;
+        bytes.extend_from_slice(&PKGALG);
+        bytes.extend_from_slice(self.keynum.as_ref());
+        bytes.extend_from_slice(&self.sig);
 
-        Ok(w)
+        bytes
     }
 }
 
@@ -211,5 +229,51 @@ fn read_base64_contents(encoded: &str) -> Result<(Vec<u8>, u64), Error> {
             Ok((data, remaining + 1))
         }
         Some(_) | None => Err(Error::UnsupportedAlgorithm),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_key_codeable() {
+        let key = PublicKey {
+            keynum: KeyNumber::new([3u8; KeyNumber::LEN]),
+            key: [4u8; PUBLIC_KEY_LEN],
+        };
+
+        let bytes = key.as_bytes();
+        let deserialized = PublicKey::from_bytes(&bytes).unwrap();
+        assert_eq!(key, deserialized)
+    }
+
+    #[test]
+    fn private_key_codeable() {
+        let key = PrivateKey {
+            keynum: KeyNumber::new([3u8; KeyNumber::LEN]),
+            public_key_alg: PKGALG,
+            kdf_alg: crate::consts::KDFALG,
+            kdf_rounds: crate::consts::DEFAULT_KDF_ROUNDS,
+            salt: [5u8; 16],
+            checksum: [3u8; 8],
+            complete_key: Zeroizing::new([7u8; FULL_KEY_LEN]),
+        };
+
+        let bytes = key.as_bytes();
+        let deserialized = PrivateKey::from_bytes(&bytes).unwrap();
+        assert_eq!(key, deserialized)
+    }
+
+    #[test]
+    fn signature_codeable() {
+        let sig = Signature {
+            keynum: KeyNumber::new([3u8; KeyNumber::LEN]),
+            sig: [9u8; SIG_LEN],
+        };
+
+        let bytes = sig.as_bytes();
+        let deserialized = Signature::from_bytes(&bytes).unwrap();
+        assert_eq!(sig, deserialized)
     }
 }

--- a/libsignify/src/encoding.rs
+++ b/libsignify/src/encoding.rs
@@ -3,7 +3,7 @@ use crate::consts::{
 };
 use crate::errors::{Error, FormatError};
 use crate::{KeyNumber, PrivateKey, PublicKey, Signature};
-use std::io::Write;
+use alloc::vec::Vec;
 use zeroize::Zeroizing;
 
 /// A structure that can be converted to and from bytes and the `signify` file format.
@@ -53,10 +53,12 @@ pub trait Codeable: Sized + Sealed {
         let mut file_bytes = Vec::new();
 
         file_bytes.extend_from_slice(COMMENT_HEADER.as_bytes());
-        writeln!(file_bytes, "{}", comment).unwrap();
+        file_bytes.extend_from_slice(comment.as_bytes());
+        file_bytes.push(b'\n');
 
         let out = base64::encode(&bytes);
-        writeln!(file_bytes, "{}", out).unwrap();
+        file_bytes.extend_from_slice(out.as_bytes());
+        file_bytes.push(b'\n');
 
         file_bytes
     }
@@ -130,7 +132,7 @@ impl Codeable for PrivateKey {
         buf.read_exact(&mut public_key_alg)?;
         buf.read_exact(&mut kdf_alg)?;
         let kdf_rounds = {
-            let mut bytes = [0u8; std::mem::size_of::<u32>()];
+            let mut bytes = [0u8; core::mem::size_of::<u32>()];
             buf.read_exact(&mut bytes)?;
             u32::from_be_bytes(bytes)
         };

--- a/libsignify/src/errors.rs
+++ b/libsignify/src/errors.rs
@@ -1,12 +1,11 @@
 use crate::consts::KeyNumber;
 use std::fmt::{self, Display};
-use std::io;
 
 /// The error type which is returned when some `signify` operation fails.
 #[derive(Debug)]
 pub enum Error {
-    /// An I/O error occured working with structure data.
-    Io(io::Error),
+    /// Not enough data was found to parse a structure.
+    InsufficentData,
     /// Parsing a structure's data yielded an error.
     InvalidFormat(FormatError),
     /// The key algorithm used was unknown and unsupported.
@@ -31,7 +30,7 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Io(e) => Display::fmt(e, f),
+            Error::InsufficentData => f.write_str("insufficent data while parsing structure"),
             Error::InvalidFormat(e) => Display::fmt(e, f),
             Error::UnsupportedAlgorithm => f.write_str("encountered unsupported key algorithm"),
             Error::MismatchedKey { expected, found } => {
@@ -86,12 +85,6 @@ impl std::error::Error for FormatError {}
 impl From<FormatError> for Error {
     fn from(e: FormatError) -> Self {
         Self::InvalidFormat(e)
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Self {
-        Self::Io(e)
     }
 }
 

--- a/libsignify/src/errors.rs
+++ b/libsignify/src/errors.rs
@@ -1,5 +1,8 @@
 use crate::consts::KeyNumber;
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
+
+#[cfg(feature = "std")]
+extern crate std;
 
 /// The error type which is returned when some `signify` operation fails.
 #[derive(Debug)]
@@ -46,6 +49,7 @@ impl Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 /// The error that is returned when a file's contents didn't adhere
@@ -80,6 +84,7 @@ impl Display for FormatError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for FormatError {}
 
 impl From<FormatError> for Error {
@@ -91,10 +96,14 @@ impl From<FormatError> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::fmt::{Debug, Display};
     use static_assertions::assert_impl_all;
-    use std::error::Error as StdError;
-    use std::fmt::{Debug, Display};
 
-    assert_impl_all!(Error: Debug, Display, StdError, Send, Sync);
-    assert_impl_all!(FormatError: Debug, Display, StdError, Send, Sync);
+    #[cfg(feature = "std")]
+    assert_impl_all!(Error: std::error::Error);
+    #[cfg(feature = "std")]
+    assert_impl_all!(FormatError: std::error::Error);
+
+    assert_impl_all!(Error: Debug, Display, Send, Sync);
+    assert_impl_all!(FormatError: Debug, Display, Send, Sync);
 }

--- a/libsignify/src/key.rs
+++ b/libsignify/src/key.rs
@@ -71,6 +71,7 @@ impl std::fmt::Debug for NewKeyOpts {
 ///
 /// You will need this if you want to create signatures.
 #[derive(Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))] // Makes the encoding tests nicer.
 pub struct PrivateKey {
     pub(crate) public_key_alg: [u8; 2],
     pub(crate) kdf_alg: [u8; 2],

--- a/libsignify/src/key.rs
+++ b/libsignify/src/key.rs
@@ -1,10 +1,11 @@
 use crate::consts::{KeyNumber, FULL_KEY_LEN, KDFALG, PKGALG, PUBLIC_KEY_LEN, SIG_LEN};
 use crate::errors::Error;
 
+use alloc::string::String;
+use core::convert::TryInto;
+use core::ops::DerefMut;
 use ed25519_dalek::{Digest, Sha512};
 use rand_core::{CryptoRng, RngCore};
-use std::convert::TryInto;
-use std::ops::DerefMut;
 use zeroize::{Zeroize, Zeroizing};
 
 /// The public half of a keypair.
@@ -54,8 +55,8 @@ impl Drop for NewKeyOpts {
     }
 }
 
-impl std::fmt::Debug for NewKeyOpts {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NewKeyOpts {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::NoEncryption => f.write_str("NoEncryption"),
             Self::Encrypted { kdf_rounds, .. } => f
@@ -234,9 +235,9 @@ impl Signature {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::fmt::Debug;
+    use core::hash::Hash;
     use static_assertions::assert_impl_all;
-    use std::fmt::Debug;
-    use std::hash::Hash;
 
     assert_impl_all!(
         PublicKey: Clone,

--- a/libsignify/src/lib.rs
+++ b/libsignify/src/lib.rs
@@ -6,10 +6,18 @@
 //! `libsignify` can verify and create signatures that are interoperable with BSD signify.
 //! You can read more about the ideas and concepts behind `signify` in [Securing OpenBSD From Us To You](https://www.openbsd.org/papers/bsdcan-signify.html).
 //!
+//! This crate is `#![no_std]` by default, but still relies on `liballoc` so your platform must
+//! provide an allocator to use `libsignify`.
+//!
+//! To enable support for `std::error::Error`, enable the `std` feature.
+//!
 //! [signify]: https://github.com/aperezdc/signify
 //! [ed25519]: https://ed25519.cr.yp.to/
 #![warn(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![no_std]
+
+extern crate alloc;
 
 pub mod consts;
 pub use consts::KeyNumber;

--- a/signify/Cargo.toml
+++ b/signify/Cargo.toml
@@ -21,4 +21,4 @@ doc = false
 clap = { version = "3.0.0-beta.5", default-features = false, features = ["cargo", "derive", "std"] }
 rand_core = { version = "0.5", features = ["getrandom"] }
 rpassword = "5"
-libsignify = { path = "../libsignify" } 
+libsignify = { path = "../libsignify", features = ["std"] } 


### PR DESCRIPTION
This makes one of the most anticipated changes I was hoping to make: switching `libsignify` to be `#![no_std]` by default so it can be used in more places.

Firstly removed the dependence on `std::io::{Read, Write}`. These changes were pretty straightforward and even had the extra plus of making all the "serialization" methods infallible. To work around having no `std::io::Read`, I borrowed [the stdlib's implementation](https://doc.rust-lang.org/stable/std/io/trait.Read.html#method.read_exact) of wrapping a slice in a reader. All it took after that was just swapping out `std::` for `core::` in a few places and double checking all the dependencies only depended on `alloc` or less.

The new `std` feature doesn't do much and simply lets the error type be coerced into `std::error::Error`. I added some GitHub actions CI to make sure the library can be built with `no_std` since the CLI enables the `std` feature by default. 

Part 3/3 of the set.