### PR TITLE
Remove unwraps on ed25519 errors

### DIFF
--- a/libsignify/src/lib.rs
+++ b/libsignify/src/lib.rs
@@ -62,8 +62,14 @@ impl PublicKey {
             });
         }
 
-        let public_key = ed25519_dalek::PublicKey::from_bytes(&self.key()).unwrap();
-        let signature = ed25519_dalek::Signature::from_bytes(&signature.signature()).unwrap();
+        // Both the key data and signature data are not verified yet,
+        // so the ed25519 math can still go wrong.
+        // In that case all we need to communicate is that it was a bad signature.
+
+        let public_key =
+            ed25519_dalek::PublicKey::from_bytes(&self.key()).map_err(|_| Error::BadSignature)?;
+        let signature = ed25519_dalek::Signature::from_bytes(&signature.signature())
+            .map_err(|_| Error::BadSignature)?;
 
         public_key
             .verify(msg, &signature)


### PR DESCRIPTION
Both the key data and signature data are not verified when a signature
verification is requested, so the ed25519 math can still go wrong.
In that case all we need to communicate is that it was a bad signature.

---

One more, please double check if I got that right.
As I can see it we load the key and signature from the files and check they have the right length, but ed25519 might still fail to do the math I guess.

(Based on #41)