### PR TITLE
Optimize CLI release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,8 @@ members = [
     "libsignify",
     "signify",
 ]
+
+[profile.release]
+codegen-units = 1
+lto = true
+panic = "abort"


### PR DESCRIPTION
These are some minor improvements to the Cargo profiles used to build the CLI version. In total, these changes add ~10 seconds to the time required for a release build, but manages to remove 184KB from the binary size, along with some performance improvements from LTO and smaller codegen units.

The speed is a nice benefit in all cases but the binary size (mostly coming from setting `panic = abort`) is nice for places like Docker containers.