### PR TITLE
Run CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, "windows-latest"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This seemed to exist at one point but didn't survive the transition to GitHub actions.