### PR TITLE
Fix some bugs and add a good many tests

### DIFF
--- a/libsignify/src/errors.rs
+++ b/libsignify/src/errors.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Display};
 extern crate std;
 
 /// The error type which is returned when some `signify` operation fails.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Not enough data was found to parse a structure.
     InsufficentData,
@@ -54,7 +54,7 @@ impl std::error::Error for Error {}
 
 /// The error that is returned when a file's contents didn't adhere
 /// to the `signify` file container format.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum FormatError {
     /// A comment line exceeded the maximum length or a data line was empty.
     LineLength,
@@ -104,6 +104,6 @@ mod tests {
     #[cfg(feature = "std")]
     assert_impl_all!(FormatError: std::error::Error);
 
-    assert_impl_all!(Error: Debug, Display, Send, Sync);
-    assert_impl_all!(FormatError: Debug, Display, Send, Sync);
+    assert_impl_all!(Error: Debug, Display, PartialEq, Send, Sync);
+    assert_impl_all!(FormatError: Debug, Display, PartialEq, Send, Sync);
 }

--- a/libsignify/src/errors.rs
+++ b/libsignify/src/errors.rs
@@ -44,7 +44,7 @@ impl Display for Error {
             )
             }
             Error::BadSignature => f.write_str("signature verification failed"),
-            Error::BadPassword => f.write_str("password was empty"),
+            Error::BadPassword => f.write_str("password was empty or incorrect for key"),
         }
     }
 }

--- a/libsignify/src/lib.rs
+++ b/libsignify/src/lib.rs
@@ -31,6 +31,9 @@ pub use errors::{Error, FormatError};
 mod key;
 pub use key::{NewKeyOpts, PrivateKey, PublicKey, Signature};
 
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 use ed25519_dalek::{Signer as _, Verifier as _};
 
 impl PrivateKey {

--- a/libsignify/src/test_utils.rs
+++ b/libsignify/src/test_utils.rs
@@ -1,0 +1,36 @@
+/// A RNG that produces numbers by incrementing a value each time.
+///
+/// Used as a fill-in for `OsRng` since it doesn't work well for the no_std tests :(
+pub struct StepperRng {
+    current: u64,
+}
+
+impl Default for StepperRng {
+    fn default() -> Self {
+        Self { current: 5 }
+    }
+}
+
+// :)
+impl rand_core::CryptoRng for StepperRng {}
+
+impl rand_core::RngCore for StepperRng {
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let out = self.current;
+        self.current = self.current.wrapping_add(1);
+        out
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        rand_core::impls::fill_bytes_via_next(self, dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}

--- a/signify/src/main.rs
+++ b/signify/src/main.rs
@@ -107,12 +107,14 @@ fn verify(
 
     let mut sig_data = BufReader::new(File::open(&signature_path)?);
 
-    let (signature, msg_data_pos): (Signature, u64) = read_base64_file(&mut sig_data)?;
+    let (signature, bytes_read): (Signature, u64) = read_base64_file(&mut sig_data)?;
 
     let mut msg = vec![];
 
     if embed {
-        sig_data.seek(SeekFrom::Start(msg_data_pos))?;
+        // Jump around past the well structured signify message to the
+        // embedded contents.
+        sig_data.seek(SeekFrom::Start(bytes_read))?;
         sig_data.read_to_end(&mut msg)?;
     } else {
         let mut msg_file = File::open(msg_path)?;


### PR DESCRIPTION
I think that this (maybe) brings the set of large, "catchup" PRs to a close :D With this, all of `libsignify`'s functionality has unit tests to check functionality within its own data produced. Also tweaked a few doc comments that were missed before.

While writing all of these, I found 2(3?) bugs:
* The remaining data calculation was very wrong parsing the base64.
    - Easy fix, just did the math in the wrong direction the first time :)
* The key checksum during generation was made after encrypting it @.@
    - This one is being blamed on too loose of typing. To fix it and maybe future issues, checksums can now only be made with a newtype wrapper that asserts the key is unencrypted.
* The wrong parts of the `complete_key` were being passed to the KDF mixer.
    - This one probably was introduced during some of the larger refactors and just wasn't caught in review, and there were not yet any tests to catch it. The tests I wrote discovered it though, so maybe proof towards their effectiveness is the right way to look at this.

The only thing after this that I can think of are some unit tests that hardcoded data created by OpenBSD's signify and check the interop. Maybe the tests could also spawn `signify-openbsd` on Linux if it detects it installed and replace the current interop bash script.