### PR TITLE
Clean up CLI parsing and support non-utf8 paths

### DIFF
--- a/signify/src/main.rs
+++ b/signify/src/main.rs
@@ -39,7 +39,7 @@ struct Args {
     /// will prompt the user for a passphrase to protect the secret key
     #[clap(short = 'n')]
     skip_key_encryption: bool,
-    /// The file containing the message to create a signature over
+    /// The file containing the message to create a signature over or to the one to verify with an existing signature
     #[clap(short, parse(from_os_str))]
     message_path: Option<PathBuf>,
     /// When signing, embed the message after the signature. When verifying,


### PR DESCRIPTION
This moves the help text to a doc comment, and performs the right `clap` invocations in order to use non-UTF-8 `PathBuf`.

Unfortunately, the naïve attempt I made failed didn't quite work right, so I had to do something a little more involved for the file extensions. That said, it should work now, and has some tests covering it.

I don't have tests covering files with non-UTF-8 paths, because such files they're hard to make, and often you cannot delete them using normal tools (certain shells and file explorers) after you make them. so I'm just going to trust that the Rust stdlib does the right thing, so long as we don't use any of the methods that require UTF-8 validity.

I also tweaked the help text in a manner requested by @BlackHoleFox via discord, e.g. removing periods.