### PR TITLE
Convert Digest output into slice without AsRef

### DIFF
--- a/libsignify/src/key.rs
+++ b/libsignify/src/key.rs
@@ -173,7 +173,7 @@ impl PrivateKey {
     fn calculate_checksum(complete_key: &UnencryptedKey) -> [u8; 8] {
         let digest = Sha512::digest(complete_key.0.as_ref());
         let mut checksum = [0; 8];
-        checksum.copy_from_slice(&digest.as_ref()[0..8]);
+        checksum.copy_from_slice(&digest.as_slice()[0..8]);
         checksum
     }
 


### PR DESCRIPTION
Newer versions of `sha2` and `digest` cause type inference issues with `.as_ref()`, leading to compilation failures if dependencies in the lockfile are newer than what this repo uses.

So instead just use a method with a concrete slice.

Closes #52