### PR TITLE
Add basic example to libsignify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         profile: minimal
         override: true
     - run: cargo test --all
+    - run: cargo test --doc
     - run: cargo test --features std
     - run: make full-cycle
     - run: make integration

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Signify - Ed25519 signature tool
 
 [![crates.io](https://img.shields.io/crates/v/signify.svg?style=flat-square)](https://crates.io/crates/signify)
-[![docs.rs docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)](https://docs.rs/libsignify)
+[![docs.rs docs](https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square)]([documentation])
 [![License: MIT](https://img.shields.io/github/license/badboy/signify-rs?style=flat-square)](LICENSE)
 [![Build Status](https://img.shields.io/github/workflow/status/badboy/signify-rs/CI/main?style=flat-square)](https://github.com/badboy/signify-rs/actions/workflows/ci.yml)
 
@@ -20,6 +20,7 @@ cargo install signify
 ```
 
 ## Usage
+The CLI is designed to be compatible with the reference implementation and accepts the same command line flags as it.
 
 Create a key pair:
 
@@ -38,6 +39,8 @@ Verify the signature:
 ```
 signify -V -p pubkey -m README.md
 ```
+
+To see how to use `libsignify`, check out the `examples/` directory or the [documentation].
 
 ## Testing
 
@@ -60,5 +63,6 @@ The complete test suite can be conveniently ran with `make test`.
 
 MIT. See [LICENSE](LICENSE).
 
+[documentation]: https://docs.rs/libsignify
 [signify]: https://github.com/aperezdc/signify
 [ed25519]: https://ed25519.cr.yp.to/

--- a/libsignify/examples/basic.rs
+++ b/libsignify/examples/basic.rs
@@ -1,0 +1,47 @@
+//! Basic example that shows how to verify a signature of some file.
+//!
+//! You could, for example, replace the file reading with a HTTP client.
+use libsignify::{Codeable, PublicKey, Signature};
+use std::{fs, path::Path};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("verifying signature of message file");
+
+    // Boilerplate so this code can run both via `cargo test --doc` and `cargo run --example`.
+    // Not relevant to the example otherwise.
+    let base_path = if std::env::var("CARGO_CRATE_NAME").is_ok() {
+        Path::new("./examples/")
+    } else {
+        Path::new("./libsignify/examples/")
+    };
+
+    // First, open the message to verify the validity of.
+    let message = fs::read(base_path.join("message.txt"))?;
+
+    // Then, get the public key of the signer.
+    let (signer_id, _) = {
+        let public_key_contents = fs::read_to_string(base_path.join("test_key.pub"))?;
+
+        PublicKey::from_base64(&public_key_contents)?
+    };
+
+    // Now, fetch the signature we have for the message.
+    //
+    // This could be from anywhere trusted, including a HTTP server for example.
+    let (signature, _) = {
+        let signature_contents = fs::read_to_string(base_path.join("message.txt.sig"))?;
+        Signature::from_base64(&signature_contents)?
+    };
+
+    // With all of the parts needed, the message can be checked now.
+    match signer_id.verify(&message, &signature) {
+        Ok(()) => {
+            println!("message was verified!");
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("message did not verify: {}", e);
+            Err(Box::new(e))
+        }
+    }
+}

--- a/libsignify/examples/message.txt
+++ b/libsignify/examples/message.txt
@@ -1,0 +1,1 @@
+Was I tampered with?

--- a/libsignify/examples/message.txt.sig
+++ b/libsignify/examples/message.txt.sig
@@ -1,0 +1,2 @@
+untrusted comment: signature from signify secret key
+RWQEC93KpsGY1ra0DC0VQbBys7cJn8ql2GwQT++FPD3DikMSpW5neGMeQBi4cuJjeZJkJCHipOQ0R45RLRgGFu1pFZqyRBfTLQM=

--- a/libsignify/examples/test_key.pub
+++ b/libsignify/examples/test_key.pub
@@ -1,0 +1,2 @@
+untrusted comment: signify-rs demo public key
+RWQEC93KpsGY1ru5XOWxiNxzzmA1qw3mNk5Kbg01y1BOyfcPQW0vOIQp

--- a/libsignify/examples/test_key.sec
+++ b/libsignify/examples/test_key.sec
@@ -1,0 +1,2 @@
+untrusted comment: signify-rs demo secret key
+RWRCSwAAAAB5yy4ID9IWOh3gaWDT6zAj6Xi5hsLcWz0EC93KpsGY1g6BU//xXcmvE753Yos+Fsw7fSpzK14Pro9zhh9r2Bu+u7lc5bGI3HPOYDWrDeY2TkpuDTXLUE7J9w9BbS84hCk=

--- a/libsignify/src/lib.rs
+++ b/libsignify/src/lib.rs
@@ -11,6 +11,12 @@
 //!
 //! To enable support for `std::error::Error`, enable the `std` feature.
 //!
+//! ## Examples
+//! A simple CLI that verifies some example data:
+//! ```rust
+#![doc = include_str!("../examples/basic.rs")]
+//! ```
+//!
 //! [signify]: https://github.com/aperezdc/signify
 //! [ed25519]: https://ed25519.cr.yp.to/
 #![warn(missing_docs)]


### PR DESCRIPTION
Closes #51

The include is used so that we get a nice example on docs.rs without any code duplication. Rendered:

![image](https://user-images.githubusercontent.com/20936452/170894356-2bbd64b5-7abf-4113-8f04-8bb3a4e2c15b.png)
