### PR TITLE
Verify loaded keys are valid

### DIFF
--- a/libsignify/src/errors.rs
+++ b/libsignify/src/errors.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Display};
 extern crate std;
 
 /// The error type which is returned when some `signify` operation fails.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     /// Not enough data was found to parse a structure.
     InsufficentData,
@@ -57,7 +57,7 @@ impl std::error::Error for Error {}
 
 /// The error that is returned when a file's contents didn't adhere
 /// to the `signify` file container format.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FormatError {
     /// A comment line exceeded the maximum length or a data line was empty.
     LineLength,

--- a/libsignify/src/errors.rs
+++ b/libsignify/src/errors.rs
@@ -20,6 +20,8 @@ pub enum Error {
         /// ID of the key that tried to verify the signature, but was wrong.
         found: KeyNumber,
     },
+    /// The wrong public key was associated with the full keypair.
+    WrongKey,
     /// The signature didn't match the expected result.
     ///
     /// This could be the result of data corruption or malicious tampering.
@@ -43,6 +45,7 @@ impl Display for Error {
                 found,
             )
             }
+            Error::WrongKey => f.write_str("public key does not belong to the private key"),
             Error::BadSignature => f.write_str("signature verification failed"),
             Error::BadPassword => f.write_str("password was empty or incorrect for key"),
         }

--- a/libsignify/src/key.rs
+++ b/libsignify/src/key.rs
@@ -73,7 +73,7 @@ struct UnencryptedKey(Zeroizing<[u8; FULL_KEY_LEN]>);
 ///
 /// You will need this if you want to create signatures.
 #[derive(Clone)]
-#[cfg_attr(test, derive(Debug, PartialEq))] // Makes the encoding tests nicer.
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))] // Makes the encoding tests nicer.
 pub struct PrivateKey {
     pub(crate) public_key_alg: [u8; 2],
     pub(crate) kdf_alg: [u8; 2],

--- a/libsignify/src/lib.rs
+++ b/libsignify/src/lib.rs
@@ -45,8 +45,12 @@ use ed25519_dalek::{Signer as _, Verifier as _};
 impl PrivateKey {
     /// Signs a message with this secret key and returns the signature.
     pub fn sign(&self, msg: &[u8]) -> Signature {
-        // This `unwrap` is erased in release mode.
-        let keypair = ed25519_dalek::Keypair::from_bytes(self.complete_key.as_ref()).unwrap();
+        // This panics because signing is otherwise infallible if the key is valid.
+        //
+        // All constructors of `PrivateKey` return a valid one, so this is better then forcing
+        // a caller to handle an impossible error.
+        let keypair = PrivateKey::into_keypair(&self.complete_key)
+            .expect("invalid private keypair used for signing");
         let sig = keypair.sign(msg).to_bytes();
         Signature::new(self.keynum, sig)
     }


### PR DESCRIPTION
Inspired by [recent findings](https://github.com/MystenLabs/ed25519-unsafe-libs) about crytographically unsafe uses of Ed15519, this goes the extra mile.

While `libsignify` is not actually affected by the "issue" (APIs that allow for arbitrary public keys during signing), the thought occurred that the library can still be made more misuse resistant. To do this it now checks that a public key actually belongs to a private key. 

One could argue that this is out-of-scope for the library since, one, key encryption exists, but additionally that theres many ways key storage could go wrong or be messed with. However, this is a one-time cost and does meaningfully stop preventable user bugs that are written by mistake or unfamiliarity with key handling.