### PR TITLE
bump `curve25519-dalek` to 4.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,16 +131,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -281,12 +280,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "platforms"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
 name = "proc-macro2"


### PR DESCRIPTION
`cargo audit` detected a timing vulnerability in version 4.1.1

```
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 700 security advisories (from /Users/phil/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (54 crate dependencies)
Crate:     curve25519-dalek
Version:   4.1.1
Title:     Timing variability in `curve25519-dalek`'s `Scalar29::sub`/`Scalar52::sub`
Date:      2024-06-18
ID:        RUSTSEC-2024-0344
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0344
Solution:  Upgrade to >=4.1.3
Dependency tree:
curve25519-dalek 4.1.1
└── ed25519-dalek 2.0.0
    └── libsignify 0.6.0
        └── signify 0.6.0

error: 1 vulnerability found!
```